### PR TITLE
Updated manpage to have correct binary name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: required
 dist: trusty
 language: generic
 install: git clone https://github.com/QubesOS/qubes-builder ~/qubes-builder
-# debootstrap in trusty is old...
-before_script: sudo ln -s sid /usr/share/debootstrap/scripts/stretch
 script: ~/qubes-builder/scripts/travis-build
 env:
  - DIST_DOM0=fc20 USE_QUBES_REPO_VERSION=3.1

--- a/qvm-convert-img.1
+++ b/qvm-convert-img.1
@@ -1,12 +1,12 @@
-.TH qvm-img-convert 1
+.TH qvm-convert-img 1
 .SH NAME
-qvm-img-convert \- convert image file to simple trusted representation
+qvm-convert-img \- convert image file to simple trusted representation
 .SH SYNOPSIS
-.B qvm-img-convert
+.B qvm-convert-img
 .IR input-file 
 .IR output-file 
 .SH DESCRIPTION
-.B qvm-img-convert
+.B qvm-convert-img
 modifies image files by processing them using the 
 .B convert
 tool from imagemagick. Processing is done in a disposable qube, and the


### PR DESCRIPTION
Previously read qvm-img-convert, now reads qvm-convert-img
Updated .travis.yml to fix build failure.