### PR TITLE
 Fixed qvm-get-image and qvm-get-tinted-image for Qubes 4

### DIFF
--- a/qvm-get-image
+++ b/qvm-get-image
@@ -15,36 +15,38 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-import argparse
-import qubes.qubes
-import qubes.imgconverter
+import qubesadmin.tools
+import qubesimgconverter
+import sys
 
-parser = argparse.ArgumentParser(
+parser = qubesadmin.tools.QubesArgumentParser(
+        vmname_nargs=1,
         description='Secure copy of images between virtual machines',
         epilog='Both SRC and DST may specify format in ImageMagick(1) way,\n'
         'i.e. png:aqq.gif')
 
-parser.add_argument('vmname', metavar='VMNAME', help='Source VM')
 parser.add_argument('src', metavar='SRC', help='Path inside source VM')
 parser.add_argument('dst', metavar='DST', help='Destination path in this VM')
 
+
 def main():
     args = parser.parse_args()
-    
-    qvm_collection = qubes.qubes.QubesVmCollection()
-    qvm_collection.lock_db_for_reading()
-    qvm_collection.load()
-    qvm_collection.unlock_db()
+    domains = args.domains or args.app.domains
 
-    vm = qvm_collection.get_vm_by_name(args.vmname)
+    if not domains:
+        print("No domain found") >> sys.stderr
+        return
+    else:
+        vm = domains[0]
 
     if vm is None:
         parser.error('No such VM: {0}'.format(args.vmname))
 
-    qubes.imgconverter.Image.get_from_vm(vm, args.src).save(args.dst)
+    qubesimgconverter.Image.get_from_vm(vm, args.src).save(args.dst)
+
 
 if __name__ == '__main__':
     main()

--- a/qvm-get-image
+++ b/qvm-get-image
@@ -33,13 +33,7 @@ parser.add_argument('dst', metavar='DST', help='Destination path in this VM')
 
 def main():
     args = parser.parse_args()
-    domains = args.domains or args.app.domains
-
-    if not domains:
-        parser.error("No domain found")
-        return
-    else:
-        vm = domains[0]
+    vm = args.domains[0]
 
     if vm is None:
         parser.error('No such VM: {0}'.format(args.vmname))

--- a/qvm-get-image
+++ b/qvm-get-image
@@ -20,7 +20,6 @@
 
 import qubesadmin.tools
 import qubesimgconverter
-import sys
 
 parser = qubesadmin.tools.QubesArgumentParser(
         vmname_nargs=1,
@@ -37,7 +36,7 @@ def main():
     domains = args.domains or args.app.domains
 
     if not domains:
-        print("No domain found") >> sys.stderr
+        parser.error("No domain found")
         return
     else:
         vm = domains[0]

--- a/qvm-get-tinted-image
+++ b/qvm-get-tinted-image
@@ -15,37 +15,39 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import argparse
-import qubes.qubes
-import qubes.imgconverter
+import qubesadmin.tools
+import qubesimgconverter
 
-parser = argparse.ArgumentParser(
+parser = qubesadmin.tools.QubesArgumentParser(
+        vmname_nargs=1,
         description='Secure copy of images between virtual machines',
         epilog='Both SRC and DST may specify format in ImageMagick(1) way,\n'
         'i.e. png:aqq.gif')
 
-parser.add_argument('vmname', metavar='VMNAME', help='Source VM')
 parser.add_argument('colour', metavar='COLOUR', help='Colour')
 parser.add_argument('src', metavar='SRC', help='Path inside source VM')
 parser.add_argument('dst', metavar='DST', help='Destination path in this VM')
 
+
 def main():
     args = parser.parse_args()
-    
-    qvm_collection = qubes.qubes.QubesVmCollection()
-    qvm_collection.lock_db_for_reading()
-    qvm_collection.load()
-    qvm_collection.unlock_db()
+    domains = args.domains or args.app.domains
 
-    vm = qvm_collection.get_vm_by_name(args.vmname)
+    if not domains:
+        parser.error("No domain found")
+        return
+    else:
+        vm = domains[0]
 
     if vm is None:
         parser.error('No such VM: {0}'.format(args.vmname))
 
-    qubes.imgconverter.Image.get_from_vm(vm, args.src).colorise(args.dst, args.colour)
+    qubesimgconverter.Image.get_from_vm(vm, args.src)\
+        .tint(args.colour).save(args.dst)
+
 
 if __name__ == '__main__':
     main()

--- a/qvm-get-tinted-image
+++ b/qvm-get-tinted-image
@@ -34,13 +34,7 @@ parser.add_argument('dst', metavar='DST', help='Destination path in this VM')
 
 def main():
     args = parser.parse_args()
-    domains = args.domains or args.app.domains
-
-    if not domains:
-        parser.error("No domain found")
-        return
-    else:
-        vm = domains[0]
+    vm = args.domains[0]
 
     if vm is None:
         parser.error('No such VM: {0}'.format(args.vmname))


### PR DESCRIPTION
API changes made in QubesOS 4 had broken the qvm-get-image  and qvm-get-tinted-image commands, that let to safely copy pictures from  domains to dom0. I adapted those scripts to let them work fine also on QubesOS 4.

