### PR TITLE
fix: add existence check to image file

### DIFF
--- a/qvm-convert-img
+++ b/qvm-convert-img
@@ -7,5 +7,10 @@ if [ $# -ne 2 ] ; then
         exit 1
 fi
 
+if [ ! -f "$1" ] ; then
+        echo "image file does not exists: $1"
+        exit 1
+fi
+
 exec /usr/lib/qubes/qrexec-client-vm '@dispvm' qubes.GetImageRGBA \
 	/usr/lib/qubes/qimg-convert-client "$@"


### PR DESCRIPTION
Stumbled on this when calling `qvm-convert-img` and mistyped the file name, I had to wait until the DisposableVM finished its launch to get the error message. Nautilus & Gnome scripts already do their existence check so no change is needed on those.